### PR TITLE
Quick Cleanup/Abstraction

### DIFF
--- a/Resizr.xcodeproj/project.pbxproj
+++ b/Resizr.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		32378812223AC119009F4D04 /* CALayer+Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32378810223AC118009F4D04 /* CALayer+Utility.swift */; };
+		32378813223AC119009F4D04 /* NSDraggingInfo+Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32378811223AC119009F4D04 /* NSDraggingInfo+Utility.swift */; };
 		6E7997E2222EEE1600850D97 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7997E1222EEE1600850D97 /* AppDelegate.swift */; };
 		6E7997E4222EEE1600850D97 /* HomeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E7997E3222EEE1600850D97 /* HomeController.swift */; };
 		6E7997E6222EEE1700850D97 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6E7997E5222EEE1700850D97 /* Assets.xcassets */; };
@@ -18,6 +20,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		32378810223AC118009F4D04 /* CALayer+Utility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "CALayer+Utility.swift"; path = "Resizr/Utility/CALayer+Utility.swift"; sourceTree = SOURCE_ROOT; };
+		32378811223AC119009F4D04 /* NSDraggingInfo+Utility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSDraggingInfo+Utility.swift"; path = "Resizr/Utility/NSDraggingInfo+Utility.swift"; sourceTree = SOURCE_ROOT; };
 		6E7997DE222EEE1600850D97 /* Resizr.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Resizr.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E7997E1222EEE1600850D97 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6E7997E3222EEE1600850D97 /* HomeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeController.swift; sourceTree = "<group>"; };
@@ -42,6 +46,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3237880F223AC10B009F4D04 /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				32378810223AC118009F4D04 /* CALayer+Utility.swift */,
+				32378811223AC119009F4D04 /* NSDraggingInfo+Utility.swift */,
+			);
+			name = Utility;
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		6E7997D5222EEE1600850D97 = {
 			isa = PBXGroup;
 			children = (
@@ -61,6 +75,7 @@
 		6E7997E0222EEE1600850D97 /* Resizr */ = {
 			isa = PBXGroup;
 			children = (
+				3237880F223AC10B009F4D04 /* Utility */,
 				6E7997E1222EEE1600850D97 /* AppDelegate.swift */,
 				6EF404AE22302F7200A57454 /* DragViewDelegate.swift */,
 				6E7997F1222EEEC300850D97 /* DragView.swift */,
@@ -155,6 +170,8 @@
 				6EF404B122302F9F00A57454 /* NSImage+Resized.swift in Sources */,
 				6EF404AF22302F7200A57454 /* DragViewDelegate.swift in Sources */,
 				6E7997E2222EEE1600850D97 /* AppDelegate.swift in Sources */,
+				32378813223AC119009F4D04 /* NSDraggingInfo+Utility.swift in Sources */,
+				32378812223AC119009F4D04 /* CALayer+Utility.swift in Sources */,
 				6E7997F2222EEEC300850D97 /* DragView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -295,7 +312,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resizr/Resizr.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = J24764G4F3;
+				DEVELOPMENT_TEAM = PXCNFGS7X2;
 				INFOPLIST_FILE = Resizr/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -315,7 +332,7 @@
 				CODE_SIGN_ENTITLEMENTS = Resizr/Resizr.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = J24764G4F3;
+				DEVELOPMENT_TEAM = PXCNFGS7X2;
 				INFOPLIST_FILE = Resizr/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Resizr/AppDelegate.swift
+++ b/Resizr/AppDelegate.swift
@@ -11,16 +11,5 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-
-
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Insert code here to initialize your application
-    }
-
-    func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
-    }
-
-
 }
 

--- a/Resizr/DragView.swift
+++ b/Resizr/DragView.swift
@@ -12,27 +12,21 @@ class DragView: NSView {
     
     var delegate: DragViewDelegate?
     
-    var filePath: String?
+    private var filePath: String?
     private var acceptedFileExtensions = ["jpg", "png"]
-
-    override func draw(_ dirtyRect: NSRect) {
-        super.draw(dirtyRect)
-
-        
-    }
     
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
         
         self.wantsLayer = true
-        self.layer?.backgroundColor = NSColor.gray.cgColor
+        layer?.appearActive(false)
         
         registerForDraggedTypes([NSPasteboard.PasteboardType.URL, NSPasteboard.PasteboardType.fileURL])
     }
     
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         if checkExtension(sender) == true {
-            self.layer?.backgroundColor = NSColor.blue.cgColor
+            layer?.appearActive(true)
             return .copy
         } else {
             return NSDragOperation()
@@ -40,27 +34,27 @@ class DragView: NSView {
     }
     
     override func draggingEnded(_ sender: NSDraggingInfo) {
-        self.layer?.backgroundColor = NSColor.gray.cgColor
+        layer?.appearActive(false)
     }
     
     override func draggingExited(_ sender: NSDraggingInfo?) {
-        self.layer?.backgroundColor = NSColor.gray.cgColor
+        layer?.appearActive(false)
     }
     
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        guard let pasteboard = sender.draggingPasteboard.propertyList(forType: NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")) as? NSArray,
-            let path = pasteboard[0] as? String
-        else { return false }
+        guard let path = sender.path else {
+            return false
+        }
         
         let url = URL(fileURLWithPath: path)
         delegate?.dragView(didDragFileWith: url)
         return true
     }
     
-    fileprivate func checkExtension(_ drag: NSDraggingInfo) -> Bool {
-        guard let board = drag.draggingPasteboard.propertyList(forType: NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")) as? NSArray,
-            let path = board[0] as? String
-            else { return false }
+    private func checkExtension(_ drag: NSDraggingInfo) -> Bool {
+        guard let path = drag.path else {
+            return false
+        }
         
         let suffix = URL(fileURLWithPath: path).pathExtension
         for ext in self.acceptedFileExtensions {

--- a/Resizr/HomeController.swift
+++ b/Resizr/HomeController.swift
@@ -10,10 +10,10 @@ import Cocoa
 
 class HomeController: NSViewController {
     
-    @IBOutlet var dragView: DragView!
-    @IBOutlet weak var imageView: NSImageView!
+    @IBOutlet private var dragView: DragView!
+    @IBOutlet private weak var imageView: NSImageView!
     
-    var selectedFolder: URL?
+    private var selectedFolder: URL?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,11 +21,11 @@ class HomeController: NSViewController {
         title = "Resizr"
     }
     
-    @IBAction func openSelection(_ sender: Any) {
+    @IBAction private func openSelection(_ sender: Any) {
         save(image: imageView.image!)
     }
     
-    func selectFolder() {
+    private func selectFolder() {
         guard let window = view.window else { return }
         
         let panel = NSOpenPanel()
@@ -35,18 +35,12 @@ class HomeController: NSViewController {
         
         panel.beginSheetModal(for: window) { (result) in
             if result == NSApplication.ModalResponse.OK {
-                self.selectedFolder = panel.urls[0]
+                self.selectedFolder = panel.urls.first
             }
         }
     }
 
-    override var representedObject: Any? {
-        didSet {
-        // Update the view, if already loaded.
-        }
-    }
-
-    func infoAbout(url: URL) -> String {
+    private func infoAbout(url: URL) -> String {
         
         let fileManager = FileManager.default
         
@@ -65,7 +59,7 @@ class HomeController: NSViewController {
         }
     }
     
-    func resize(image: NSImage, completion: @escaping ([String: NSImage]?, String?) -> ()) {
+    private func resize(image: NSImage, completion: @escaping ([String: NSImage]?, String?) -> ()) {
         var images = [String: NSImage]()
         let sizes = ["Icon-App-20x20@1x.png": 20,
                      "Icon-App-20x20@2x.png": 40,
@@ -102,7 +96,7 @@ class HomeController: NSViewController {
         }
     }
     
-    func save(image: NSImage) {
+    private func save(image: NSImage) {
         resize(image: image) { (imagesDict, errorString) in
             if let error = errorString {
                 print(error)

--- a/Resizr/Utility/CALayer+Utility.swift
+++ b/Resizr/Utility/CALayer+Utility.swift
@@ -1,0 +1,18 @@
+//
+//  NSColor+Utility.swift
+//  Resizr
+//
+//  Created by Kyle Bendelow on 3/14/19.
+//  Copyright © 2019 Onur Geneş. All rights reserved.
+//
+
+import Cocoa
+
+internal extension CALayer {
+    /// Will make the parent view appear active or inactive (e.g. "active" setting will make the view turn blue)
+    func appearActive(_ active: Bool) {
+        // TODO: Make this look nice, apply fades, etc
+        let color = active ? NSColor.blue : NSColor.gray
+        backgroundColor = color.cgColor
+    }
+}

--- a/Resizr/Utility/NSDraggingInfo+Utility.swift
+++ b/Resizr/Utility/NSDraggingInfo+Utility.swift
@@ -1,0 +1,23 @@
+//
+//  NSDraggingInfo+Utility.swift
+//  Resizr
+//
+//  Created by Kyle Bendelow on 3/14/19.
+//  Copyright © 2019 Onur Geneş. All rights reserved.
+//
+
+import Cocoa
+
+extension NSDraggingInfo {
+    /// Returns path of dragged item if available 
+    var path: String? {
+        guard let pasteboard = draggingPasteboard.propertyList(forType: NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")) as? NSArray else {
+            return nil
+        }
+        guard let path = pasteboard.firstObject as? String else {
+            return nil
+        }
+        
+        return path
+    }
+}


### PR DESCRIPTION
* Remove unused boilerplate methods. 
* Add encapsulation scope to variables and functions. 
* Remove index of 0 logic in lieu of Swifty .first getter. 
* Add utility classes for CALayer and NSDragging info to abstract redundant logic